### PR TITLE
chore: bump cache and aws credentials action versions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ runs:
       uses: p6m7g8-actions/node-yarn-setup@main
     - name: Restore NPM node_modules cache
       if: ${{ !contains(github.event.head_commit.message, 'chore(release):') }}
-      uses: actions/cache/restore@v5.0.1
+      uses: actions/cache/restore@v5.0.3
       with:
         path: node_modules
         key: ${{ runner.os }}-yarn-node_modules-${{ hashFiles('yarn.lock') }}
@@ -70,7 +70,7 @@ runs:
         yarn explain peer-requirements
     - name: Cache NPM dependencies
       if: ${{ !contains(github.event.head_commit.message, 'chore(release):') }}
-      uses: actions/cache@v5.0.1
+      uses: actions/cache@v5.0.3
       with:
         path: node_modules
         key: ${{ runner.os }}-yarn-node_modules-${{ hashFiles('yarn.lock') }}
@@ -140,7 +140,7 @@ runs:
         fi
     - name: Assume role using OIDC
       if: ${{ steps.bump.outputs.bump == 'true' && !contains(github.event.head_commit.message, 'chore(release):') }}
-      uses: aws-actions/configure-aws-credentials@v5.1.1
+      uses: aws-actions/configure-aws-credentials@v6.0.0
       with:
         aws-region: ${{ inputs.aws_region }}
         role-to-assume: ${{ inputs.aws_role }}


### PR DESCRIPTION
## Summary
- bump `actions/cache/restore` from `v5.0.1` to `v5.0.3`
- bump `actions/cache` from `v5.0.1` to `v5.0.3`
- bump `aws-actions/configure-aws-credentials` from `v5.1.1` to `v6.0.0`

## Validation
- `act --container-architecture linux/amd64 --container-daemon-socket - --container-options "--memory 4g" workflow_dispatch -W .github/workflows/build.yml -j build -s GITHUB_TOKEN="$TOKEN"`
- result: success
